### PR TITLE
Don't update blocking stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.4
+- Make new instance from blocking stub
+
 # 0.1.3
 - Update httpcomponents depedency
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.vendasta</groupId>
     <artifactId>vax.v1</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <name>vax</name>
     <url>http://github.com/vendasta/vax-java</url>
     <description>

--- a/src/main/java/com/vendasta/vax/GRPCClient.java
+++ b/src/main/java/com/vendasta/vax/GRPCClient.java
@@ -51,20 +51,21 @@ public abstract class GRPCClient<T extends io.grpc.stub.AbstractStub<T>> extends
 
     protected <V> V doRequest(String func, com.google.protobuf.AbstractMessage request, RequestOptions.Builder builder) throws SDKException {
         RequestOptions options = this.buildVAXOptions(builder);
+        T stub;
         if (options.getTimeout() > 0) {
-            blockingStub = blockingStub.withDeadlineAfter((long) (options.getTimeout() * 1000), TimeUnit.MICROSECONDS);
+            stub = blockingStub.withDeadlineAfter((long) (options.getTimeout() * 1000), TimeUnit.MICROSECONDS);
         } else {
-            blockingStub = blockingStub.withDeadlineAfter(1, TimeUnit.DAYS);
+            stub = blockingStub.withDeadlineAfter(1, TimeUnit.DAYS);
         }
 
         if (options.getIncludeToken()) {
-            blockingStub = blockingStub.withCallCredentials(credentialsManager);
+            stub = stub.withCallCredentials(credentialsManager);
         } else {
-            blockingStub = blockingStub.withCallCredentials(null);
+            stub = stub.withCallCredentials(null);
         }
 
         try {
-            Object resp = blockingStub.getClass().getMethod(func, request.getClass()).invoke(blockingStub, request);
+            Object resp = stub.getClass().getMethod(func, request.getClass()).invoke(stub, request);
             return (V) resp;
         } catch (InvocationTargetException e) {
             throw new SDKException(e.getTargetException().getMessage());


### PR DESCRIPTION
We are looking into Hearst's deadline exceeds. We have yet to reproduce it on our end. One suspicion is that we are modifying the client's blocking stub field.

Adding options to a blocking stub will return a new instance of the blocking stub. So if we have a new stub on `doRequest`, and this way we never modify the blockingstub field on the client. This _may_ mitigate the issue.

@byates-va @vendasta/iam-legend @sgryschuk-va 