### PR TITLE
MCR-211: (fix) Use Maven's docker image directly instead of the one we built

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -57,8 +57,31 @@ steps:
     path: /ciphers
   - name: pass
     path: /pass
-- name: 'gcr.io/repcore-prod/mvn-deploy:5'
+- name: 'maven:3.9-openjdk-21'
   waitFor: ['key', 'password', 'passphrase']
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    # Import GPG key
+    gpg --import /key/key.asc
+    
+    # Set up Maven settings with credentials
+    mkdir -p ~/.m2
+    cat > ~/.m2/settings.xml <<EOF
+    <settings>
+      <servers>
+        <server>
+          <id>ossrh</id>
+          <username>vendasta</username>
+          <password>$(cat /pass/password)</password>
+        </server>
+      </servers>
+    </settings>
+    EOF
+    
+    # Deploy to Maven Central
+    mvn clean deploy -Dgpg.passphrase=$(cat /pass/passphrase)
   volumes:
   - name: key
     path: /key

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,7 @@
         </developer>
     </developers>
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <scm>


### PR DESCRIPTION
[MCR-211] @vendasta/matchcraft-red 

[MCR-211]: https://vendasta.jira.com/browse/MCR-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ