### PR TITLE
fix: update GPG plugin and add javadoc to resolve CI build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/src/main/java/com/vendasta/vax/CredentialsException.java
+++ b/src/main/java/com/vendasta/vax/CredentialsException.java
@@ -1,5 +1,11 @@
 package com.vendasta.vax;
 
+/**
+ * Exception thrown when there are issues with credential management.
+ * 
+ * <p>This includes problems with loading credentials, token refresh failures,
+ * and authentication errors.
+ */
 public class CredentialsException extends RuntimeException {
     /**
      * Because we inherit from Serializable, this is a requirement. It is used
@@ -8,6 +14,11 @@ public class CredentialsException extends RuntimeException {
      */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new credentials exception with the specified message.
+     * 
+     * @param message the error message
+     */
     public CredentialsException(String message) {
         super(message);
     }

--- a/src/main/java/com/vendasta/vax/Environment.java
+++ b/src/main/java/com/vendasta/vax/Environment.java
@@ -1,5 +1,15 @@
 package com.vendasta.vax;
 
+/**
+ * Enumeration of supported VAX environments.
+ */
 public enum  Environment {
-    LOCAL, TEST, DEMO, PROD
+    /** Local development environment. */
+    LOCAL, 
+    /** Testing environment. */
+    TEST, 
+    /** Demo environment. */
+    DEMO, 
+    /** Production environment. */
+    PROD
 }

--- a/src/main/java/com/vendasta/vax/EnvironmentConfig.java
+++ b/src/main/java/com/vendasta/vax/EnvironmentConfig.java
@@ -1,5 +1,11 @@
 package com.vendasta.vax;
 
+/**
+ * Configuration for VAX environment settings.
+ * 
+ * <p>This class encapsulates the connection details for a specific
+ * VAX environment including host, URL, and security settings.
+ */
 public class EnvironmentConfig {
     private final String url;
     private final String host;
@@ -12,18 +18,36 @@ public class EnvironmentConfig {
         this.secure = builder.secure;
     }
 
+    /**
+     * Returns whether this environment uses secure connections.
+     * 
+     * @return true if HTTPS/secure gRPC should be used
+     */
     public boolean isSecure() {
         return secure;
     }
 
+    /**
+     * Returns the base URL for this environment.
+     * 
+     * @return the base URL
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * Returns the hostname for this environment.
+     * 
+     * @return the hostname
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Builder for configuring EnvironmentConfig instances.
+     */
     public static class Builder {
         private String host;
         private String url;
@@ -55,6 +79,11 @@ public class EnvironmentConfig {
         }
     }
 
+    /**
+     * Creates a new builder for EnvironmentConfig.
+     * 
+     * @return new builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/com/vendasta/vax/HTTPClient.java
+++ b/src/main/java/com/vendasta/vax/HTTPClient.java
@@ -16,7 +16,22 @@ import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 
-
+/**
+ * Abstract HTTP client for making HTTP requests to VAX services.
+ * 
+ * <p>This client provides a fluent builder pattern for configuration and supports
+ * various authentication methods including environment variables, credential objects,
+ * and service account streams.
+ * 
+ * <p>Example usage:
+ * <pre>{@code
+ * HTTPClient client = HTTPClient.builder()
+ *     .host("api.example.com")
+ *     .secure(true)
+ *     .defaultTimeout(10000)
+ *     .build();
+ * }</pre>
+ */
 public abstract class HTTPClient extends VAXClient implements AutoCloseable {
     private static final Gson GSON = new Gson();
     
@@ -45,6 +60,9 @@ public abstract class HTTPClient extends VAXClient implements AutoCloseable {
             .build();
     }
 
+    /**
+     * Builder for configuring HTTPClient instances.
+     */
     public static class Builder {
         private String host;
         private boolean secure = true; // Default to secure
@@ -52,33 +70,69 @@ public abstract class HTTPClient extends VAXClient implements AutoCloseable {
         private VAXCredentials.Credentials credentials;
         private InputStream serviceAccount;
 
+        /**
+         * Sets the hostname for the HTTP client.
+         * 
+         * @param host the hostname (required)
+         * @return this builder instance
+         */
         public Builder host(String host) {
             this.host = host;
             return this;
         }
 
+        /**
+         * Sets whether to use HTTPS.
+         * 
+         * @param secure true for HTTPS, false for HTTP (default: true)
+         * @return this builder instance
+         */
         public Builder secure(boolean secure) {
             this.secure = secure;
             return this;
         }
 
+        /**
+         * Sets the default timeout for HTTP requests.
+         * 
+         * @param defaultTimeout timeout in milliseconds (default: 10000)
+         * @return this builder instance
+         */
         public Builder defaultTimeout(float defaultTimeout) {
             this.defaultTimeout = defaultTimeout;
             return this;
         }
 
+        /**
+         * Sets custom credentials for authentication.
+         * 
+         * @param credentials the credentials object
+         * @return this builder instance
+         */
         public Builder credentials(VAXCredentials.Credentials credentials) {
             this.credentials = credentials;
             this.serviceAccount = null; // Clear other credential source
             return this;
         }
 
+        /**
+         * Sets service account credentials from an input stream.
+         * 
+         * @param serviceAccount input stream containing service account JSON
+         * @return this builder instance
+         */
         public Builder serviceAccount(InputStream serviceAccount) {
             this.serviceAccount = serviceAccount;
             this.credentials = null; // Clear other credential source
             return this;
         }
 
+        /**
+         * Builds the HTTPClient instance.
+         * 
+         * @return configured HTTPClient instance
+         * @throws SDKException if configuration is invalid
+         */
         public HTTPClient build() throws SDKException {
             if (host == null || host.trim().isEmpty()) {
                 throw new SDKException("Host cannot be null or empty");
@@ -87,6 +141,11 @@ public abstract class HTTPClient extends VAXClient implements AutoCloseable {
         }
     }
 
+    /**
+     * Creates a new builder for configuring HTTPClient.
+     * 
+     * @return new builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }
@@ -134,6 +193,17 @@ public abstract class HTTPClient extends VAXClient implements AutoCloseable {
         }
     }
 
+    /**
+     * Executes an HTTP request to the specified path.
+     * 
+     * @param <V> the response type
+     * @param path the API path
+     * @param req the request protobuf message
+     * @param responseType the response builder
+     * @param builder the request options builder
+     * @return the parsed response
+     * @throws SDKException if the request fails
+     */
     protected <V extends AbstractMessage.Builder<V>> V doRequest(String path, com.google.protobuf.AbstractMessage req, V responseType, RequestOptions.Builder builder) throws SDKException {
         Objects.requireNonNull(path, "Path cannot be null");
         Objects.requireNonNull(req, "Request cannot be null");

--- a/src/main/java/com/vendasta/vax/RequestOptions.java
+++ b/src/main/java/com/vendasta/vax/RequestOptions.java
@@ -1,5 +1,11 @@
 package com.vendasta.vax;
 
+/**
+ * Configuration options for individual API requests.
+ * 
+ * <p>This class allows customization of request behavior including
+ * timeouts and authentication settings.
+ */
 public class RequestOptions {
     private Boolean includeToken = true;
     private Float timeout = 10000f;
@@ -22,6 +28,9 @@ public class RequestOptions {
     }
 
 
+    /**
+     * Builder for configuring RequestOptions.
+     */
     public static class Builder {
         private Boolean includeToken;
         private Float timeout;

--- a/src/main/java/com/vendasta/vax/SDKException.java
+++ b/src/main/java/com/vendasta/vax/SDKException.java
@@ -1,5 +1,12 @@
 package com.vendasta.vax;
 
+/**
+ * Exception thrown by VAX SDK operations.
+ * 
+ * <p>This exception wraps various types of errors that can occur during
+ * SDK operations including network errors, authentication failures,
+ * and service errors.
+ */
 public class SDKException extends RuntimeException {
     /**
      * Because we inherit from Serializable, this is a requirement. It is used
@@ -10,6 +17,11 @@ public class SDKException extends RuntimeException {
     private io.grpc.Status status;
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new SDK exception with the specified message.
+     * 
+     * @param message the error message
+     */
     public SDKException(String message) {
         super(message);
         status = io.grpc.Status.UNAVAILABLE;
@@ -20,6 +32,12 @@ public class SDKException extends RuntimeException {
         status = e.getStatus();
     }
 
+    /**
+     * Creates a new SDK exception with the specified message and cause.
+     * 
+     * @param message the error message
+     * @param t the underlying cause
+     */
     public SDKException(String message, Throwable t) {
         super(message, t);
         status = io.grpc.Status.UNAVAILABLE;

--- a/src/main/java/com/vendasta/vax/VAXCredentials.java
+++ b/src/main/java/com/vendasta/vax/VAXCredentials.java
@@ -32,7 +32,19 @@ import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
-
+/**
+ * VAX credentials implementation for authentication with VAX services.
+ * 
+ * <p>This class handles authentication token management, including automatic
+ * token refresh and JWT signing for service-to-service communication.
+ * 
+ * <p>Credentials can be loaded from:
+ * <ul>
+ *   <li>Environment variable (VENDASTA_APPLICATION_CREDENTIALS)</li>
+ *   <li>Input stream containing service account JSON</li>
+ *   <li>Credentials object with explicit values</li>
+ * </ul>
+ */
 public class VAXCredentials extends CallCredentials {
     private VAXCredentialsManager credentialsManager;
     private final Metadata.Key<String> AUTHORIZATION = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
@@ -74,10 +86,21 @@ public class VAXCredentials extends CallCredentials {
     }
 
 
+    /**
+     * Gets the current authorization token for HTTP requests.
+     * 
+     * @return the authorization token (including "Bearer " prefix)
+     */
     public String getAuthorizationToken() {
         return credentialsManager.getAuthorization();
     }
 
+    /**
+     * Container for service account credentials.
+     * 
+     * <p>This class holds the necessary information for authenticating
+     * with VAX services using service account credentials.
+     */
     public static class Credentials {
         @SerializedName("private_key_id")
         private String privateKeyID;


### PR DESCRIPTION
- Update maven-gpg-plugin from 1.5 to 3.1.0 to fix --pinentry-mode error
- Add comprehensive javadoc comments to all public APIs
- Reduce javadoc warnings from 68 to enable successful Maven Central deployment

[MCR-211] @vendasta/matchcraft-red 

[MCR-211]: https://vendasta.jira.com/browse/MCR-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ