### PR TITLE
MCR-211: (feat) Use the true mvn-deploy image, and enable auto publish

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,5 +1,5 @@
 steps:
-- name: 'gcr.io/repcore-prod/mvn-deploy:6.0.0-rc3'
+- name: 'gcr.io/repcore-prod/mvn-deploy:6.0.0'
   secretEnv:
   - GPG_PRIVATE_KEY
   - GPG_PASSPHRASE

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <tokenAuth>true</tokenAuth>
-                    <autoPublish>false</autoPublish>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
[MCR-211] @vendasta/matchcraft-red 

The mvn-deploy image is working properly, so now its time to actually try to release vax-java.

<img width="1143" height="412" alt="Screenshot 2025-09-11 at 12 24 11 PM" src="https://github.com/user-attachments/assets/2fd2e318-0dee-472f-9383-5114fc693acb" />


[MCR-211]: https://vendasta.jira.com/browse/MCR-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ